### PR TITLE
Proper Exit Code for tests/checks.sh

### DIFF
--- a/tests/checks.sh
+++ b/tests/checks.sh
@@ -51,3 +51,8 @@ done
 echo -----------------------------------------------
 echo ---- $nfail Tests failed
 echo ---- $npass Tests passed
+
+# Proper Exit Code
+#      0 - Success
+# Not(0) - Fail (1 or more tests)
+exit $nfail


### PR DESCRIPTION
The commit in this PR makes `tests/checks.sh` return success or failure depending on whether all tests passed. When at least one test fails, the proper exit code propagates through `make`, to set the status of the running CI Workflow to that of having failed.

This should be the last modification to complete issue #9 which refers to adding a CI Workflow.