### PR TITLE
Fix #29: HDF5 on Expanse

### DIFF
--- a/dependencies/_install.sh
+++ b/dependencies/_install.sh
@@ -117,7 +117,7 @@ log_filepath=$log_dir"/HDF5.log"
 
 cd $src_dir"/HDF5"
     echo "|  |--> Configuring (./configure)..."
-    ./configure --prefix=$build_dir --enable-parallel --enable-deprecated-symbols > $log_filepath 2>&1
+    ./configure CC=mpicc CXX=mpicxx --prefix=$build_dir --enable-parallel --enable-deprecated-symbols > $log_filepath 2>&1
 
     echo "|  |--> Building (w/ Make)..."
     make "$@" >> $log_filepath 2>&1


### PR DESCRIPTION
Fix Issue #29 whereby HDF5 didn't build on Expanse. The error was fixed by requiring `mpicc` and `mpicxx` to be used in order for it to find MPI headers and binaries.