### PR TITLE
Fix #30 (Silo on Bridges2) & Color Output

### DIFF
--- a/dependencies/_install.sh
+++ b/dependencies/_install.sh
@@ -239,5 +239,5 @@ echo "|-----------------------------------------------------|"
 echo -e "\n$FG_NONE"
 
 if [ "$found_dotfile_count" -ne "0" ]; then
-    echo -e "$FG_ORANGE\n\n[WARNING] MFC's dependency install script added code to $found_dotfile_count dotfiles ($found_dotfile_list_string) in order to correctly configure your environement variables (such as LD_LIBRARY_PATH). Please restart your shell before running MFC. \n\n$FG_NONE"
+    echo -e "$FG_ORANGE\n\n[WARNING] MFC's dependency install script added code to $found_dotfile_count dotfiles ($found_dotfile_list_string) in order to correctly configure your environement variables (such as LD_LIBRARY_PATH). Please start a new shell session (e.g exec \$SHELL) before running MFC or source one of the listed dotfiles (e.g source ~/.bashrc). \n\n$FG_NONE"
 fi

--- a/dependencies/install.sh
+++ b/dependencies/install.sh
@@ -1,24 +1,23 @@
 #!/bin/bash
 
+# Color ANSI Escape Sequences
+FG_RED='\033[0;31m'
+FG_NONE='\033[0m'
+
 ./_install.sh "$@"
 
 exit_code=$?
 
 if [ $exit_code -ne 0 ]; then
-    echo 
-    echo
-    echo 
-    echo 
-    echo "========================================================================"
-    echo "| Fatal Error"
-    echo "| ---> Exit Code ($exit_code)"
-    echo "| ---> Some stages output logs to log/"
-    echo "| ---> Please ensure your build environment is adequate (view README.md)"
-    echo "========================================================================"
-    echo 
-    echo
-    echo 
-    echo
+    echo -e "$FG_RED\n\n\n"
+    echo "==========================================================================="
+    echo "| Fatal Error:                                                            |"
+    echo "| ---> Exit Code ($exit_code).                                             "
+    echo "| ---> Take a look at the output above.                                   |"
+    echo "| ---> Some stages output logs to log/.                                   |"
+    echo "| ---> Please ensure your build environment is adequate (view README.md). |"
+    echo "==========================================================================="
+    echo -e "\n\n\n$FG_NONE"
 fi
 
 exit $exit_code


### PR DESCRIPTION
Herein, we:
- Fix issue #30 wherein running `python2 input.py post_process` failed because the dynamic loader couldn't locate the silo shared library. We export the path to the directory containing the library to `LD_LIBRARY_PATH` and make it permanent by bootstrapping some code to users' dotfiles (`~/.bashrc`, ...).
- Add colored output to the install script for added clarity. 